### PR TITLE
1452 Удобный/простой/лёгкий вариант смены сообщения "Экземпляр процесса №___ запущен"

### DIFF
--- a/wfe-web/src/main/java/ru/runa/wf/web/MessagesProcesses.java
+++ b/wfe-web/src/main/java/ru/runa/wf/web/MessagesProcesses.java
@@ -33,6 +33,7 @@ public final class MessagesProcesses {
     public static final StrutsMessage LABEL_SHOW_DEPLOY_DEFINITION_CONTROLS = new StrutsMessage("label.show_deploy_definition_controls");
     public static final StrutsMessage LABEL_HIDE_DEPLOY_DEFINITION_CONTROLS = new StrutsMessage("label.hide_deploy_definition_controls");
     public static final StrutsMessage PROCESS_STARTED = new StrutsMessage("process.started");
+    public static final StrutsMessage PROCESS_STARTED_CUSTOM = new StrutsMessage("process.started.custom")
     public static final StrutsMessage PROCESS_ACTIVATE = new StrutsMessage("process.activate");
     public static final StrutsMessage PROCESS_ACTIVATE_FAILED_TOKENS = new StrutsMessage("process.activate.failed.tokens");
     public static final StrutsMessage PROCESS_ACTIVATED = new StrutsMessage("process.activated");

--- a/wfe-web/src/main/java/ru/runa/wf/web/action/StartProcessAction.java
+++ b/wfe-web/src/main/java/ru/runa/wf/web/action/StartProcessAction.java
@@ -33,6 +33,7 @@ import ru.runa.common.web.action.ActionBase;
 import ru.runa.common.web.form.IdForm;
 import ru.runa.wf.web.MessagesProcesses;
 import ru.runa.wf.web.form.StartProcessForm;
+import ru.runa.wfe.commons.PropertyResources;
 import ru.runa.wfe.definition.dto.WfDefinition;
 import ru.runa.wfe.form.Interaction;
 import ru.runa.wfe.service.delegate.Delegates;
@@ -49,7 +50,7 @@ import ru.runa.wfe.user.Profile;
  * @struts.action-forward name="tasksList" path="/manage_tasks.do" redirect = "true"
  */
 public class StartProcessAction extends ActionBase {
-
+    private static final PropertyResources RESOURCES = new PropertyResources("struts.properties");
     @Override
     public ActionForward execute(ActionMapping mapping, ActionForm form, HttpServletRequest request, HttpServletResponse response) {
         StartProcessForm startProcessForm = (StartProcessForm) form;
@@ -67,7 +68,11 @@ public class StartProcessAction extends ActionBase {
             } else {
                 WfDefinition definition = Delegates.getDefinitionService().getProcessDefinition(getLoggedUser(request), definitionId);
                 Long processId = Delegates.getExecutionService().startProcess(getLoggedUser(request), definition.getName(), null);
-                addMessage(request, new ActionMessage(MessagesProcesses.PROCESS_STARTED.getKey(), processId.toString()));
+                if(RESOURCES.getStringProperty(MessagesProcesses.PROCESS_STARTED_CUSTOM.getKey()).equals("") ){
+                    addMessage(request, new ActionMessage(MessagesProcesses.PROCESS_STARTED.getKey(),processId.toString()));
+                }else {
+                    addMessage(request, new ActionMessage(RESOURCES.getStringProperty(MessagesProcesses.PROCESS_STARTED_CUSTOM.getKey()).replace("{0}",processId.toString()),false));
+                }
                 forward = mapping.findForward(Resources.FORWARD_SUCCESS);
                 if (WebResources.isAutoShowForm()) {
                     Profile profile = ProfileHttpSessionHelper.getProfile(request.getSession());

--- a/wfe-web/src/main/java/ru/runa/wf/web/action/SubmitStartProcessFormAction.java
+++ b/wfe-web/src/main/java/ru/runa/wf/web/action/SubmitStartProcessFormAction.java
@@ -29,6 +29,7 @@ import ru.runa.common.web.form.IdForm;
 import ru.runa.wf.web.FormSubmissionUtils;
 import ru.runa.wf.web.MessagesProcesses;
 import ru.runa.wf.web.form.CommonProcessForm;
+import ru.runa.wfe.commons.PropertyResources;
 import ru.runa.wfe.definition.dto.WfDefinition;
 import ru.runa.wfe.execution.dto.WfProcess;
 import ru.runa.wfe.form.Interaction;
@@ -47,7 +48,7 @@ import ru.runa.wfe.user.User;
  * @struts.action-forward name="tasksList" path="/manage_tasks.do" redirect = "true"
  */
 public class SubmitStartProcessFormAction extends BaseProcessFormAction {
-
+    private static final PropertyResources RESOURCES = new PropertyResources("struts.properties");
     @Override
     protected Long executeProcessFromAction(HttpServletRequest request, ActionForm actionForm, ActionMapping mapping, Profile profile) {
         User user = getLoggedUser(request);
@@ -71,7 +72,11 @@ public class SubmitStartProcessFormAction extends BaseProcessFormAction {
 
     @Override
     protected ActionMessage getMessage(Long processId) {
-        return new ActionMessage(MessagesProcesses.PROCESS_STARTED.getKey(), processId.toString());
+        if(RESOURCES.getStringProperty(MessagesProcesses.PROCESS_STARTED_CUSTOM.getKey()).equals("") ){
+            return new ActionMessage(MessagesProcesses.PROCESS_STARTED.getKey(),processId.toString());
+        }else {
+            return new ActionMessage(RESOURCES.getStringProperty(MessagesProcesses.PROCESS_STARTED_CUSTOM.getKey()).replace("{0}",processId.toString()),false);
+        }
     }
 
     protected ActionForward getForward(ActionMapping mapping) {

--- a/wfe-web/src/main/resources/settingsList.xml
+++ b/wfe-web/src/main/resources/settingsList.xml
@@ -73,6 +73,10 @@
 		<value>HIDDEN</value>
 		<value>DISABLED</value>
 	</properties_file>
+
+	<properties_file title="struts.properties">
+		<property title="process.started.custom"/>
+	</properties_file>
 	
 	<properties_file title="web.properties">
 		<property title="group.subprocess.enabled">

--- a/wfe-web/src/main/webapp/WEB-INF/classes/settingsDescriptions.properties
+++ b/wfe-web/src/main/webapp/WEB-INF/classes/settingsDescriptions.properties
@@ -122,3 +122,6 @@ securitycheck.properties_permission.check.required.RELATION = Check relation
 securitycheck.properties_permission.check.required.BOTSTATIONS = Check bot stations
 securitycheck.properties_permission.check.required.SYSTEM = Check system
 securitycheck.properties_permission.check.required.DATASOURCES = Check datasources
+
+struts.properties = Message settings
+struts.properties_process.started.custom = change the message template to start the process (enter {0} to add the process ID to the message)

--- a/wfe-web/src/main/webapp/WEB-INF/classes/settingsDescriptions_ru.properties
+++ b/wfe-web/src/main/webapp/WEB-INF/classes/settingsDescriptions_ru.properties
@@ -123,3 +123,6 @@ securitycheck.properties_permission.check.required.RELATION=\u041F\u0440\u0438\u
 securitycheck.properties_permission.check.required.BOTSTATIONS=\u041F\u0440\u0438\u043C\u0435\u043D\u044F\u0442\u044C \u043A \u0431\u043E\u0442-\u0441\u0442\u0430\u043D\u0446\u0438\u044F\u043C
 securitycheck.properties_permission.check.required.SYSTEM=\u041F\u0440\u0438\u043C\u0435\u043D\u044F\u0442\u044C \u043A \u0434\u0435\u0439\u0441\u0442\u0432\u0438\u044F\u043C \u0441 \u0441\u0438\u0441\u0442\u0435\u043C\u043E\u0439
 securitycheck.properties_permission.check.required.DATASOURCES=\u041F\u0440\u0438\u043C\u0435\u043D\u044F\u0442\u044C \u0434\u043B\u044F \u0438\u0441\u0442\u043E\u0447\u043D\u0438\u043A\u043E\u0432 \u0434\u0430\u043D\u043D\u044B\u0445 
+
+struts.properties = Настройки сообщений
+struts.properties_process.started.custom = изменить шаблон сообщения для запуска процесса (вставьте {0} для добавления ID процесса в ваш шаблон сообщения)

--- a/wfe-web/src/main/webapp/WEB-INF/classes/struts.properties
+++ b/wfe-web/src/main/webapp/WEB-INF/classes/struts.properties
@@ -479,6 +479,7 @@ process.restore.failure.ONLY_ASYNC_SUBPROCESS_CAN_BE_RESTORED = Unable to restor
 process.restore.failure.PROCESS_HAS_BEEN_COMPLETED = Unable to restore completed process
 process.restore.failure.UNABLE_TO_FIND_ACTIVE_TOKENS_BY_PROCESS_END_DATE = Unable to find any active tokens at process end (old processes cannot be restored)
 process.started  = Process {0} has been started
+process.started.custom =
 process.upgrade.to.definition.version = Upgrade to definition version
 process.upgraded.to.definition.version = Process was upgraded
 processes.upgrade.to.definition.version = Switch all running instances to another definition version


### PR DESCRIPTION
Добавлен пункт в настройках для изменения шаблона сообщения при запуске нового процесса.

В классах StartProcessAction и SubmitStartProcessFormAction добавлено условие для выбора использования пользовательского шаблона сообщения или стандартного.
